### PR TITLE
Fix web app speaker diarization and language handling

### DIFF
--- a/web/app/src/hooks/useRecording.ts
+++ b/web/app/src/hooks/useRecording.ts
@@ -7,7 +7,7 @@ import {
   isAudioCaptureSupported,
 } from '@/lib/audioCapture';
 import { createTranscriptionSocket } from '@/lib/transcriptionSocket';
-import { processInProgressConversation } from '@/lib/api';
+import { processInProgressConversation, getUserLanguage } from '@/lib/api';
 
 /**
  * Hook to manage recording lifecycle.
@@ -66,8 +66,17 @@ export function useRecording() {
     pausedDurationRef.current = 0;
 
     try {
+      // Fetch user's language preference (fallback to 'multi' if not available)
+      let language = 'multi';
+      try {
+        language = await getUserLanguage();
+      } catch (langErr) {
+        console.warn('Failed to fetch user language, using multi:', langErr);
+      }
+
       // Create transcription socket
       const socket = createTranscriptionSocket({
+        language,
         onSegment: (segment: TranscriptSegment) => {
           if (!isMountedRef.current) return;
           setSegments((prev) => {

--- a/web/app/src/lib/transcriptionSocket.ts
+++ b/web/app/src/lib/transcriptionSocket.ts
@@ -241,7 +241,7 @@ export class TranscriptionSocket {
             const segment: TranscriptSegment = {
               id: segmentData.id || `seg-${Date.now()}-${Math.random()}`,
               text: segmentData.text || '',
-              speaker: parseSpeakerId(segmentData.speakerId ?? segmentData.speaker),
+              speaker: parseSpeakerId(segmentData.speakerId ?? segmentData.speaker_id ?? segmentData.speaker),
               isUser: segmentData.isUser ?? segmentData.is_user ?? false,
               timestamp: Date.now(),
             };
@@ -256,7 +256,7 @@ export class TranscriptionSocket {
           const segment: TranscriptSegment = {
             id: data.id || `seg-${Date.now()}-${Math.random()}`,
             text: data.text,
-            speaker: parseSpeakerId(data.speakerId ?? data.speaker),
+            speaker: parseSpeakerId(data.speakerId ?? data.speaker_id ?? data.speaker),
             isUser: data.isUser ?? data.is_user ?? false,
             timestamp: Date.now(),
           };


### PR DESCRIPTION
Issues:
1. Speaker diarization: Web app checked for 'speakerId' (camelCase) but
   backend sends 'speaker_id' (snake_case). This caused all speakers to
   be identified as speaker 0 because the fallback string parsing
   incorrectly assumed 1-indexed speakers when Deepgram uses 0-indexed.

2. Language support: Web app always used 'multi' regardless of user's
   language preference, unlike mobile/desktop which fetch user settings.
   This caused issues for users with single_language_mode enabled.

Fixes:
- Add 'speaker_id' (snake_case) to the fallback chain in segment parsing
- Fetch user's language preference before creating transcription socket

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Addresses diarization and language config discrepancies between web and backend.
> 
> - In `useRecording.ts`, fetches user language via `getUserLanguage()` before starting, passes `language` to `createTranscriptionSocket`, with fallback to `multi` on failure
> - In `transcriptionSocket.ts`, updates segment parsing to include `speaker_id` alongside `speakerId`/`speaker` when computing `speaker`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2c2534388ca86904b060543c7dcbf3b934717b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->